### PR TITLE
Remove attack and place ship methods to prepare migration to mechanics

### DIFF
--- a/backend/gameplay/ship/ship.cpp
+++ b/backend/gameplay/ship/ship.cpp
@@ -19,14 +19,6 @@ void Ship::setShipProperties(string shipName, string shipDirection, int shipLeng
     isSunk = false;
 }
 
-Ship::placeShip(Board& board, int x, int y, string dir) {
-    
-}
-
-Ship::attackShip(Board& board, int x, int y) {
-
-}
-
 // TODO: Move to UI
 Ship::displayShipInfo() {
     cout << "Ship Name: " << name << endl;

--- a/backend/gameplay/ship/ship.h
+++ b/backend/gameplay/ship/ship.h
@@ -9,10 +9,6 @@ class Ship {
     public:
         Ship(); // Constructor to initialize the ship
         void setShipProperties(string, string, int); // Method to set ship properties
-
-        void placeShip(Board&, int, int, string); // Method to place the ship on the board
-        void attackShip(Board&, int, int); // Method to attack the ship
-
         void displayShipInfo(); // Method to get ship information
 
     private:


### PR DESCRIPTION
This pull request simplifies the `Ship` class in the gameplay backend by removing unimplemented methods related to ship placement and attack. This helps clarify the class's responsibilities and reduces unnecessary code.

Prepare to move those functions to `mechanics` folder.

Codebase simplification:

* Removed the `placeShip` and `attackShip` methods from both the `Ship` class declaration in `ship.h` and their empty implementations in `ship.cpp`, as they were not implemented and are likely not needed in the current design. [[1]](diffhunk://#diff-23d274072f548253833cdc90395f4e7083b9b4e53f6b80bd0036235f70c237c4L12-L15) [[2]](diffhunk://#diff-16c6f1a8f01a89510fc0986afad11026893bbc56545a6e61a279c667cc56031fL22-L29)