### PR TITLE
Migrate space mechanics function

### DIFF
--- a/backend/gameplay/mechanics/mechanics.cpp
+++ b/backend/gameplay/mechanics/mechanics.cpp
@@ -44,44 +44,6 @@ Board attackShipOnBoard(Board &board, int row, int col) {
     return board;
 }
 
-// Helper functions
-bool checkEmptyCell(std::string cell) {
-    return cell == "[ ]"; // Assuming "[ ]" represents an empty cell
-}
-
-bool checkOutOfBounds(Board &board, int row, int col) {
-    if (row < 0 || row >= board.getBoard().size() || col < 0 || col >= board.getBoard()[0].size()) {
-        return true; // Out of bounds
-    }
-    return false; // Within bounds
-}
-
-bool checkAvailableSpace(Board &board, Ship &ship, int row, int col, string direction) {
-    /*
-    Check if the ship can be placed at the given position without going out of bounds or overlapping other ships.
-
-    1. Check if the ship fits within the board boundaries based on its direction and length. Horizontal ships extend to the right, vertical ships extend downwards.
-
-    2. Check each cell the ship would occupy to ensure it is empty (i.e., contains "[ ]").
-    */
-    if (direction == "horizontal") {
-        for (int i = 0; i < ship.getLength(); i++) {
-            if (checkOutOfBounds(board, row, col + i) || !checkEmptyCell(board.getBoard()[row][col + i])) {
-                return false; // Out of bounds or cell not empty
-            }
-        }
-    } else if (direction == "vertical") {
-        for (int i = 0; i < ship.getLength(); i++) {
-            if (checkOutOfBounds(board, row + i, col) || !checkEmptyCell(board.getBoard()[row + i][col])) {
-                return false; // Out of bounds or cell not empty
-            }
-        }
-    } else {
-        return false; // Invalid direction
-    }
-    return true; // Space is available
-}
-
 // Check for sunk ships
 bool checkShipSunk(Ship &ship) {
     return ship.checkIsSunk();    

--- a/backend/gameplay/mechanics/mechanics.h
+++ b/backend/gameplay/mechanics/mechanics.h
@@ -13,11 +13,6 @@ void endGame();
 Board addShipToBoard(Board&, Ship&, int, int, std::string);
 Board attackShipOnBoard(Board&, int, int);
 
-// Helper functions
-bool checkEmptyCell(std::string);
-bool checkOutOfBounds(Board&, int, int);
-bool checkAvailableSpace(Board&, Ship&, int, int, std::string);
-
 // Check for sunk ships
 bool checkShipSunk(Ship&);
 bool checkAllShipsSunk(Board&);

--- a/backend/gameplay/mechanics/space/space.cpp
+++ b/backend/gameplay/mechanics/space/space.cpp
@@ -1,0 +1,43 @@
+#include "board.h"
+#include "ship.h"
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+bool checkEmptyCell(std::string cell) {
+    return cell == "[ ]"; // Assuming "[ ]" represents an empty cell
+}
+
+bool checkOutOfBounds(Board &board, int row, int col) {
+    if (row < 0 || row >= board.getBoard().size() || col < 0 || col >= board.getBoard()[0].size()) {
+        return true; // Out of bounds
+    }
+    return false; // Within bounds
+}
+
+bool checkAvailableSpace(Board &board, Ship &ship, int row, int col, string direction) {
+    /*
+    Check if the ship can be placed at the given position without going out of bounds or overlapping other ships.
+
+    1. Check if the ship fits within the board boundaries based on its direction and length. Horizontal ships extend to the right, vertical ships extend downwards.
+
+    2. Check each cell the ship would occupy to ensure it is empty (i.e., contains "[ ]").
+    */
+    if (direction == "horizontal") {
+        for (int i = 0; i < ship.getLength(); i++) {
+            if (checkOutOfBounds(board, row, col + i) || !checkEmptyCell(board.getBoard()[row][col + i])) {
+                return false; // Out of bounds or cell not empty
+            }
+        }
+    } else if (direction == "vertical") {
+        for (int i = 0; i < ship.getLength(); i++) {
+            if (checkOutOfBounds(board, row + i, col) || !checkEmptyCell(board.getBoard()[row + i][col])) {
+                return false; // Out of bounds or cell not empty
+            }
+        }
+    } else {
+        return false; // Invalid direction
+    }
+    return true; // Space is available
+}

--- a/backend/gameplay/mechanics/space/space.h
+++ b/backend/gameplay/mechanics/space/space.h
@@ -1,0 +1,10 @@
+#ifndef SPACE_H
+#define  SPACE_H
+
+#include <string>
+
+bool checkEmptyCell(std::string);
+bool checkOutOfBounds(Board&, int, int);
+bool checkAvailableSpace(Board&, Ship&, int, int, std::string);
+  
+#endif // SPACE_H


### PR DESCRIPTION
This pull request refactors the helper functions related to board space checking in the game mechanics module. The main change is moving the helper functions (`checkEmptyCell`, `checkOutOfBounds`, and `checkAvailableSpace`) out of `mechanics.cpp` and into a new dedicated module called `space`. This improves code organization and maintainability by separating space-related logic from the core game mechanics.

**Code organization and modularization:**

* Moved the helper functions `checkEmptyCell`, `checkOutOfBounds`, and `checkAvailableSpace` from `mechanics.cpp` to a new file `space.cpp`, and declared them in `space.h` for better separation of concerns. [[1]](diffhunk://#diff-3448dd6ef524f93944671e7bf17309f4d7d7f063fdbbf97a7a129ad782205b61L47-L84) [[2]](diffhunk://#diff-baef62fa110ad128286ddf9bb0738fd21d8b2cdb2b5367303f5fdabd77db6cd7R1-R43) [[3]](diffhunk://#diff-b7758c1c152b154560ee8ad4a7e4991f6690d8f2e2ff847dc819ce61ec7ae1e1R1-R10)
* Updated `mechanics.h` to remove declarations of these helper functions, reflecting their relocation to the new module.