### PR TITLE
Add game mechanics for checking game over and determining the winner

### DIFF
--- a/backend/gameplay/mechanics/game/include/game.h
+++ b/backend/gameplay/mechanics/game/include/game.h
@@ -1,0 +1,10 @@
+#ifndef MECHANICS_GAME_H
+#define MECHANICS_GAME_H
+
+#include "../../../board/include/board.h"
+
+bool checkGameOver(Board& player1Board, Board& player2Board);
+
+Board& checkWinner(Board& player1Board, Board& player2Board);
+
+#endif // MECHANICS_GAME_H

--- a/backend/gameplay/mechanics/game/src/game.cpp
+++ b/backend/gameplay/mechanics/game/src/game.cpp
@@ -1,0 +1,16 @@
+#include "../include/game.h"
+#include "../../../board/include/board.h"
+#include "../../mechanics/board/include/board.h"
+
+bool checkGameOver(Board& player1Board, Board& player2Board) {
+    return checkAllShipsSunk(player1Board) || checkAllShipsSunk(player2Board);
+}
+
+Board& checkWinner(Board& player1Board, Board& player2Board) {
+    if (checkAllShipsSunk(player1Board)) {
+        return player2Board; // Player 2 wins
+    } else if (checkAllShipsSunk(player2Board)) {
+        return player1Board; // Player 1 wins
+    }
+    throw std::runtime_error("No winner yet, the game is still ongoing.");
+}


### PR DESCRIPTION
This pull request introduces new game logic for determining the end of a game and identifying the winner. Two new functions, `checkGameOver` and `checkWinner`, have been added to handle these mechanics. The changes are organized as follows:

Gameplay mechanics:

* Added `checkGameOver` and `checkWinner` function declarations to the new `game.h` header file, providing interfaces for checking if the game is over and determining the winner based on the state of the players' boards.
* Implemented the `checkGameOver` and `checkWinner` functions in `game.cpp`, including logic to check if all ships have been sunk for either player and to identify the winning player or throw an error if the game is still ongoing.